### PR TITLE
added some basic petsc options to tweak

### DIFF
--- a/code/petsc_dump.py
+++ b/code/petsc_dump.py
@@ -3,7 +3,7 @@ Helper module for extracting PETSc systems of equations from Proteus
 
 Put this file in the same directory as your application
 Edit it to your needs
-Use this patch to enable the petsc_dump hooks: https://github.com/erdc-cm/proteus/commit/e7b475dea376a4100949aa807682d3192f344170
+Use this patch to enable the petsc_dump hooks: https://github.com/erdc/proteus/commit/e7b475dea376a4100949aa807682d3192f344170
 """
 
 from petsc4py import PETSc
@@ -24,7 +24,7 @@ meta = {'name': app_name,
         'models': models,
         'resolution': 'unknown'
         'sizes': 'unknown',
-        'url': 'https://github.com/erdc-cm/air-water-vv/tree/master/2d/dambreak_Ubbink',
+        'url': 'https://github.com/erdc/air-water-vv/tree/master/2d/dambreak_Ubbink',
         'versions': {'hashdist': version.hashdist,
                      'hashstack': version.hashstack,
                      'proteus': version.proteus,

--- a/petscOptions/petsc.options.asm
+++ b/petscOptions/petsc.options.asm
@@ -1,0 +1,7 @@
+-rans2p_ksp_type gmres -rans2p_pc_type asm -rans2p_pc_asm_type basic -rans2p_ksp_max_it 2000
+-rans2p_ksp_gmres_modifiedgramschmidt -rans2p_ksp_gmres_restart 300 -rans2p_sub_ksp_type preonly -rans2p_sub_pc_factor_mat_solver_package superlu -rans2p_ksp_knoll -rans2p_sub_pc_type lu
+-ncls_ksp_type   gmres -ncls_pc_type   hypre -ncls_pc_hypre_type    boomeramg -ncls_ksp_gmres_restart 300 -ncls_ksp_knoll -ncls_ksp_max_it 2000
+-vof_ksp_type    gmres -vof_pc_type    hypre -vof_pc_hypre_type     boomeramg -vof_ksp_gmres_restart 300 -vof_ksp_knoll -vof_ksp_max_it 2000
+-rdls_ksp_type   gmres -rdls_pc_type asm -rdls_pc_asm_type basic -rdls_ksp_gmres_modifiedgramschmidt -rdls_ksp_gmres_restart 300 -rdls_ksp_knoll -rdls_sub_ksp_type preonly -rdls_sub_pc_factor_mat_solver_package superlu -rdls_sub_pc_type lu -rdls_ksp_max_it 2000
+-mcorr_ksp_type  cg -mcorr_pc_type hypre -mcorr_pc_hypre_type boomeramg -mcorr_ksp_max_it 2000
+-log_summary

--- a/petscOptions/petsc.options.schur.exact
+++ b/petscOptions/petsc.options.schur.exact
@@ -1,0 +1,74 @@
+#velocity is upper, pressure is lower
+-rans2p_ksp_type fgmres
+#-rans2p_ksp_atol 1.0e-4 -rans2p_ksp_rtol 0.0
+#-rans2p_ksp_view
+#-rans2p_ksp_monitor_true_residual
+-rans2p_ksp_converged_reason
+-rans2p_pc_type fieldsplit
+# use this to discard the lower block of the LU factorization
+#-rans2p_pc_fieldsplit_type schur -rans2p_pc_fieldsplit_schur_fact_type upper -rans2p_pc_fieldsplit_schur_precondition selfp
+# use this to discard the upper block of the LU factorization
+#-rans2p_pc_fieldsplit_type schur -rans2p_pc_fieldsplit_schur_fact_type lower -rans2p_pc_fieldsplit_schur_precondition selfp
+# use full to do full Schur factorization (exact if velocity and pressure are solved exactly)
+
+#-rans2p_pc_fieldsplit_type schur -rans2p_pc_fieldsplit_schur_fact_type full -rans2p_pc_fieldsplit_schur_precondition selfp
+
+-rans2p_pc_fieldsplit_type schur -rans2p_pc_fieldsplit_schur_fact_type full -rans2p_pc_fieldsplit_schur_precondition selfp
+
+
+#-rans2p_fieldsplit_velocity_ksp_type fgmres
+#-rans2p_fieldsplit_velocity_ksp_monitor
+#-rans2p_fieldsplit_velocity_ksp_atol 1.0e-1 -rans2p_fieldsplit_velocity_ksp_rtol 1.0e-1
+#-rans2p_fieldsplit_velocity_pc_type gamg
+#-rans2p_fieldsplit_velocity_pc_type ilu
+
+
+#asm solver for velocity block
+#-rans2p_fieldsplit_velocity_ksp_monitor_true_residual
+#-rans2p_fieldsplit_velocity_ksp_type fgmres
+#-rans2p_fieldsplit_velocity_ksp_atol 1.0e-10
+#-rans2p_fieldsplit_velocity_ksp_rtol 0.0
+
+#asm with direct on blocks for velocity block
+#-rans2p_fieldsplit_velocity_pc_type asm
+#-rans2p_fieldsplit_velocity_pc_asm_type basic
+#-rans2p_fieldsplit_velocity_sub_ksp_type preonly
+#-rans2p_fieldsplit_velocity_sub_pc_type lu
+#-rans2p_fieldsplit_velocity_sub_pc_factor_mat_solver_package superlu
+
+#direct solver for  velocity block
+-rans2p_fieldsplit_velocity_ksp_type preonly
+-rans2p_fieldsplit_velocity_pc_type lu
+-rans2p_fieldsplit_velocity_pc_factor_mat_solver_package superlu_dist
+
+#"direct" solver for pressure block
+-rans2p_fieldsplit_pressure_ksp_type fgmres
+-rans2p_fieldsplit_pressure_ksp_monitor_true_residual
+-rans2p_fieldsplit_pressure_ksp_atol 1.0e-10
+-rans2p_fieldsplit_pressure_ksp_rtol 0.0
+-rans2p_fieldsplit_pressure_pc_type lu
+-rans2p_fieldsplit_pressure_pc_factor_mat_solver_package  superlu_dist
+
+#-rans2p_fieldsplit_pressure_ksp_gmres_restart 100
+#-rans2p_fieldsplit_pressure_ksp_type fgmres
+#-rans2p_fieldsplit_pressure_ksp_max_it 1
+#-rans2p_fieldsplit_pressure_ksp_monitor_true_residual
+#-rans2p_fieldsplit_pressure_ksp_atol 1.0e-5 -rans2p_fieldsplit_pressure_ksp_rtol 0.0
+#-rans2p_fieldsplit_pressure_pc_type gamg
+#-rans2p_fieldsplit_pressure_pc_type lu
+#-rans2p_fieldsplit_pressure_pc_type ilu
+#-rans2p_fieldsplit_pressure_pc_type jacobi
+#-rans2p_fieldsplit_pressure_ksp_monitor_true_residual
+#-ncls_ksp_type   fgmres -ncls_pc_type   gamg
+#-vof_ksp_type    fgmres -vof_pc_type    gamg
+#-rdls_ksp_type   fgmres -rdls_pc_type   gamg
+#-mcorr_ksp_type  cg     -mcorr_pc_type  gamg
+
+#direct  solvers for the other models
+-ncls_ksp_type   preonly -ncls_pc_type   lu -ncls_pc_factor_mat_solver_package   superlu_dist
+-vof_ksp_type    preonly -vof_pc_type    lu -vof_pc_factor_mat_solver_package    superlu_dist
+-rdls_ksp_type   preonly -rdls_pc_type   lu -rdls_pc_factor_mat_solver_package   superlu_dist
+-mcorr_ksp_type  preonly -mcorr_pc_type  lu -mcorr_pc_factor_mat_solver_package  superlu_dist
+-kappa_ksp_type preonly -kappa_pc_type lu -kappa_pc_factor_mat_solver_package superlu_dist
+-dissipation_ksp_type preonly -dissipation_pc_type lu -dissipation_pc_factor_mat_solver_package superlu_dist
+-log_summary

--- a/petscOptions/petsc.options.superlu_dist
+++ b/petscOptions/petsc.options.superlu_dist
@@ -1,0 +1,8 @@
+-rans2p_ksp_type preonly -rans2p_pc_type lu -rans2p_pc_factor_mat_solver_package superlu_dist
+-ncls_ksp_type   preonly -ncls_pc_type   lu -ncls_pc_factor_mat_solver_package   superlu_dist
+-vof_ksp_type    preonly -vof_pc_type    lu -vof_pc_factor_mat_solver_package    superlu_dist
+-rdls_ksp_type   preonly -rdls_pc_type   lu -rdls_pc_factor_mat_solver_package   superlu_dist
+-mcorr_ksp_type  preonly -mcorr_pc_type  lu -mcorr_pc_factor_mat_solver_package  superlu_dist
+-kappa_ksp_type preonly -kappa_pc_type lu -kappa_pc_factor_mat_solver_package superlu_dist
+-dissipation_ksp_type preonly -dissipation_pc_type lu -dissipation_pc_factor_mat_solver_package superlu_dist
+

--- a/systems/plunging_breakers/plunging_breakers.json
+++ b/systems/plunging_breakers/plunging_breakers.json
@@ -1,5 +1,5 @@
 {
-    "url": "https://github.com/erdc-cm/adwr-nearshore-hydro", 
+    "url": "https://github.com/erdc/adwr-nearshore-hydro", 
     "name": "plunging_breakers", 
     "dim": 2, 
     "sizes": [


### PR DESCRIPTION
@ahmadia @jedbrown while  I was testing the  strides  I  started resurrecting some of the old petsc options I had been testing to ensure that the block factorizations behave as expected theoretically. I haven't had time to clean up the petsc.options.schur.exact below, but I did test that it  converges in 1 KSP iteration.  The  current file has several other option sets included in the file and commented out.
